### PR TITLE
Fix tests failing on Go 1.20 on Windows. Clean works differently on 1…

### DIFF
--- a/middleware/context_timeout_test.go
+++ b/middleware/context_timeout_test.go
@@ -148,7 +148,7 @@ func TestContextTimeoutWithDefaultErrorMessage(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	err := m(func(c echo.Context) error {
-		if err := sleepWithContext(c.Request().Context(), time.Duration(20*time.Millisecond)); err != nil {
+		if err := sleepWithContext(c.Request().Context(), time.Duration(80*time.Millisecond)); err != nil {
 			return err
 		}
 		return c.String(http.StatusOK, "Hello, World!")
@@ -176,7 +176,7 @@ func TestContextTimeoutCanHandleContextDeadlineOnNextHandler(t *testing.T) {
 		return nil
 	}
 
-	timeout := 10 * time.Millisecond
+	timeout := 50 * time.Millisecond
 	m := ContextTimeoutWithConfig(ContextTimeoutConfig{
 		Timeout:      timeout,
 		ErrorHandler: timeoutErrorHandler,
@@ -189,11 +189,11 @@ func TestContextTimeoutCanHandleContextDeadlineOnNextHandler(t *testing.T) {
 	c := e.NewContext(req, rec)
 
 	err := m(func(c echo.Context) error {
-		// NOTE: when difference between timeout duration and handler execution time is almost the same (in range of 100microseconds)
-		// the result of timeout does not seem to be reliable - could respond timeout, could respond handler output
-		// difference over 500microseconds (0.5millisecond) response seems to be reliable
+		// extremely short periods are not reliable for tests when it comes to goroutines. We can not guarantee in which
+		// order scheduler decides do execute: 1) request goroutine, 2) timeout timer goroutine.
+		// most of the time we get result we expect but Mac OS seems to be quite flaky
 
-		if err := sleepWithContext(c.Request().Context(), time.Duration(20*time.Millisecond)); err != nil {
+		if err := sleepWithContext(c.Request().Context(), 100*time.Millisecond); err != nil {
 			return err
 		}
 

--- a/middleware/static_other.go
+++ b/middleware/static_other.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+package middleware
+
+import (
+	"os"
+)
+
+// We ignore these errors as there could be handler that matches request path.
+func isIgnorableOpenFileError(err error) bool {
+	return os.IsNotExist(err)
+}

--- a/middleware/static_windows.go
+++ b/middleware/static_windows.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"os"
+)
+
+// We ignore these errors as there could be handler that matches request path.
+//
+// As of 1.20 on Windows filepath.Clean has different behaviour on OS related filesystems so we need to use path.Clean
+// which is more suitable for path coming from web but this has some caveats on Windows. When we eventually end up in
+// os related filesystem Open methods we are getting different errors as earlier versions. As of 1.20 path checks are
+// more strict on path you provide and consider path with [UNC](https://en.wikipedia.org/wiki/Path_(computing)#UNC)
+// but missing host etc parts as invalid. Previously it would result you `fs.ErrNotExist`.
+//
+// So for 1.20@Windows we need to consider it as same not exist so we can continue next middleware/handler and not error
+// which would result status 500 instead of potential route hit or 404.
+func isIgnorableOpenFileError(err error) bool {
+	if os.IsNotExist(err) {
+		return true
+	}
+	errTxt := err.Error()
+	return errTxt == "http: invalid or unsafe file path" || errTxt == "invalid path"
+}


### PR DESCRIPTION
Fix tests failing on Go 1.20 on Windows. Clean works differently on 120. Use path.Clean instead.